### PR TITLE
Created a sample log4j2-test.xml that is automatically added on test.

### DIFF
--- a/build-resources/src/main/resources/log4j2-test.xml
+++ b/build-resources/src/main/resources/log4j2-test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="WITH_TRACE" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{hh:mm:ss.SSS} %highlight{%-5level} %-30.-30replace{'%t'}{\s}{-} %-30.30logger{1.} - %msg%n"/>
+        </Console>
+        <Console name="WITHOUT_TRACE" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{hh:mm:ss.SSS} %highlight{%-5level} %-30.-30replace{'%t'}{\s}{-} %-30.30logger{1.} - %msg%n%throwable{short.message}%n"/>
+        </Console>
+        <Async name="ASYNC">
+            <AppenderRef ref="router"/>
+        </Async>
+        
+        <Routing name="router">
+            <Routes>
+                <Script name="RoutingInit" language="JavaScript">
+                    <![CDATA[
+                        logEvent.getLevel();
+                    ]]>
+                </Script>
+                <Route ref="WITHOUT_TRACE"/>
+                <Route key="ERROR" ref="WITH_TRACE"/>
+                <Route key="WARN" ref="WITH_TRACE"/>
+            </Routes>
+        </Routing>
+    </Appenders>
+    <Loggers>
+        <!-- 8kData & ToroDB code -->
+
+        <Logger name="com.torodb" level="DEBUG" additivity="false">
+            <AppenderRef ref="ASYNC" />
+        </Logger>
+        
+        <!-- Root -->
+
+        <Root level="WARN">
+            <AppenderRef ref="ASYNC"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/parent-pom/pom.xml
+++ b/parent-pom/pom.xml
@@ -58,6 +58,30 @@
         
     </properties>
     
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -418,6 +442,34 @@
                         <goals>
                             <goal>report</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <!-- Copy a default log4j2-test config file on test-classes -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>unpack-log4j-test</id>
+                        <phase>generate-test-resources</phase>                        
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.torodb</groupId>
+                                    <artifactId>build-resources</artifactId>
+                                    <version>${torodb.build.resources.version}</version>                            
+                                </artifactItem>
+                            </artifactItems>
+                            <includes>log4j2-test.*</includes>
+                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
+                            <overWriteIfNewer>false</overWriteIfNewer>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
By doing that, Log4j2 will work withouts warnings when tests are
executed. The current system is not very configurable, but modules that
want to customize the logging can use their own log4j2-test.xml or use
the programmatic API